### PR TITLE
03-02:  update debounce.test exercise to use string argument instead of number as the solution does

### DIFF
--- a/exercises/03.date-and-time/02.problem.timers/debounce.test.ts
+++ b/exercises/03.date-and-time/02.problem.timers/debounce.test.ts
@@ -7,10 +7,10 @@ import { debounce } from './debounce.js'
 // 💰 afterAll(callback)
 
 test('executes the callback after the debounce timeout passes', () => {
-  const fn = vi.fn<[number]>()
+  const fn = vi.fn<[string]>()
   const debouncedFn = debounce(fn, 250)
 
-  // 🐨 First, call the "debounceFn" with 1 as the argument
+  // 🐨 First, call the "debounceFn" with "one" as the argument
   // and assert that the "fn" has not been called.
   // 💰 expect(fn).not.toHaveBeenCalled()
 


### PR DESCRIPTION
## Description
This pull request updates the debounce test exercise in the file `02.problem.timers/debounce.test`. The change involves modifying the test case for the debounce function to use a string argument instead of a number.

## Changes Made
- Changed the argument type in the test from `number` to `string`
- Updated the example argument from `1` to `"one"`