### PR TITLE
fix: updates MockInstance generics

### DIFF
--- a/exercises/04.globals/01.solution.global-methods/README.mdx
+++ b/exercises/04.globals/01.solution.global-methods/README.mdx
@@ -73,8 +73,7 @@ To fix this, you need to extend the type of `Console['log']` in your test and ma
 import { MockInstance } from 'vitest'
 
 declare namespace console {
-  var log: Console['log'] &
-    MockInstance<Parameters<Console['log']>, ReturnType<Console['log']>>
+  var log: Console['log'] & MockInstance<Console['log']>
 }
 ```
 


### PR DESCRIPTION
When running the workshop app, in the 04. Globals / 01. Global Methods exercise, there is a bonus point that talks about extending the global types to access `console.log.mock.calls` which otherwise would throw a type error (http://localhost:5639/exercise/04/01/solution#bonus-type-safe-global-spies)

The proposed code to do so is:

```ts
import { MockInstance } from 'vitest'

declare namespace console {
  var log: Console['log'] &
    MockInstance<Parameters<Console['log']>, ReturnType<Console['log']>>
}
```

But I don't think that's valid anymore since my TS compiler was complaining. The actual usage seems to be much simpler:

```ts
import { MockInstance } from "vitest";

declare namespace console {
  var log: Console["log"] &
    MockInstance<Console["log"]>;
}
```

While searching for docs, it seems this change has been introduced in Vitest 2.0: https://vitest.dev/guide/migration#simplified-generic-types-of-mock-functions-e-g-vi-fn-t-mock-t