### PR TITLE
[06.modules.02.solution.private-side-effects] Align types with tests and instructions

### DIFF
--- a/exercises/06.modules/02.solution.private-side-effects/@workshop/epic-sdk/telemetry.ts
+++ b/exercises/06.modules/02.solution.private-side-effects/@workshop/epic-sdk/telemetry.ts
@@ -2,7 +2,7 @@ import { setTimeout } from 'node:timers/promises'
 
 export function initTelemetry() {
   return {
-    async record(event: string, data: Record<string, unknown>) {
+    async record(event: string, data: Record<string, unknown> | null) {
       await setTimeout(6000)
     },
   }

--- a/exercises/06.modules/02.solution.private-side-effects/README.mdx
+++ b/exercises/06.modules/02.solution.private-side-effects/README.mdx
@@ -28,7 +28,7 @@ I will also provide the _factory function_ to control the exact exports returned
 ```ts filename=authorize.test.ts nonumber lines=3,7
 import { authorize, User } from './authorize.js'
 
-const queryTableMock = vi.hoisted(() => vi.fn<() => Promise<User>>())
+const queryTableMock = vi.hoisted(() => vi.fn<() => Promise<User | null>>())
 
 vi.mock(import('@workshop/epic-sdk'), async () => {
   return {
@@ -40,7 +40,7 @@ vi.mock(import('@workshop/epic-sdk'), async () => {
 :owl: Since `vi.mock()` function is _hoisted_ (gets evaluated as the first thing no matter where it's defined), it won't be able to reference any values in the test's scope, like the `queryTableMock` function. To solve this, I wrap the mock function in the [`vi.hoisted()`](https://vitest.dev/api/vi.html#vi-hoisted) utility:
 
 ```ts filename=authorize.test.ts nonumber
-const queryTableMock = vi.hoisted(() => vi.fn<() => Promise<User>>())
+const queryTableMock = vi.hoisted(() => vi.fn<() => Promise<User | null>>())
 ```
 
 This will expose the `queryTableMock` function to the `vi.mock()` factory correctly so it can use it as the value of the `queryTable` export. Nice!

--- a/exercises/06.modules/02.solution.private-side-effects/authorize.test.ts
+++ b/exercises/06.modules/02.solution.private-side-effects/authorize.test.ts
@@ -1,6 +1,6 @@
 import { authorize, User } from './authorize.js'
 
-const queryTableMock = vi.hoisted(() => vi.fn<() => Promise<User>>())
+const queryTableMock = vi.hoisted(() => vi.fn<() => Promise<User | null>>())
 
 vi.mock(import('@workshop/epic-sdk'), async () => {
   return {

--- a/exercises/06.modules/02.solution.private-side-effects/authorize.ts
+++ b/exercises/06.modules/02.solution.private-side-effects/authorize.ts
@@ -9,7 +9,7 @@ export async function authorize(userId: string) {
   // As a part of authorization, we need to query the database
   // for the given user. For that, we are using an imaginary
   // third-party SDK package that performs SQL operations for us.
-  const user = await queryTable<User>('users', {
+  const user = await queryTable<User | null>('users', {
     where: { id: { equals: userId } },
   }).catch((error) => {
     throw new Error(`Failed to fetch user by id "${userId}"`, {

--- a/exercises/06.modules/02.solution.private-side-effects/tsconfig.json
+++ b/exercises/06.modules/02.solution.private-side-effects/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "module": "NodeNext",
     "target": "ES2022",
     "esModuleInterop": true,


### PR DESCRIPTION
In a properly configured project, TypeScript throws an error in the "returns null if no user was found" test when passing `null` to `queryTableMock.mockResolvedValue` because the type of the `queryTableMock` function does not include `null`. Also, the generic type passed to `queryTable` inside the `authorize` function does not hint that the function can return `null`.

What was changed in `06.modules/02.solution.private-side-effects` folder:

- Properly configured TypeScript in the folder
- Adjusted the types in
  - Test file
  - File with `authorize` function
  - Instructions
- (Bonus) Fixed the `telemetry.record` function's signature. The issue surfaced because of the changed TypeScript config